### PR TITLE
Update RedCloth version to 4.2.7 because version 4.2.6 is yanked

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    RedCloth (4.2.6)
+    RedCloth (4.2.7)
     builder (3.0.0)
     diff-lcs (1.1.2)
     fakeweb (1.3.0)


### PR DESCRIPTION
Hi Oscar,

I could not run bundle install on my machine, it failed saying "Could not find RedCloth-4.2.6 in any of the sources". Looks like the version 4.2.6 of RedCloth is yanked (http://rubygems.org/gems/RedCloth/versions). So I've updated the Gemfile.lock to require 4.2.7. Specs are still running, are quickly trying the application locally with this new version of RedCloth, I did not find issues.
