### PR TITLE
Display repos description in the feed item descriptions

### DIFF
--- a/lib/parser.rb
+++ b/lib/parser.rb
@@ -24,8 +24,10 @@ class Parser
   def trending_repos
     section_name = 'Trending Repos'
     elements = @doc.xpath("//h2[contains(.,'#{section_name}')]/following-sibling::ol/li/h3")
-    
-    extract_repos(elements) 
+    repos = extract_repos(elements) 
+        
+    descriptions  = @doc.xpath("//h2[contains(.,'#{section_name}')]/following-sibling::ol/li/p")
+    add_descriptions(repos, descriptions)
   end
 
   private
@@ -38,6 +40,9 @@ class Parser
 
   def extract_repos(elements)
     elements.map { |element| element.xpath('a').children.map { |text| text.to_s } }
-    
+  end
+  
+  def add_descriptions(repos, descriptions)
+    repos.each_with_index { |repos, index| repos.push descriptions[index].children.first.to_s.strip }
   end
 end

--- a/spec/lib/parser_spec.rb
+++ b/spec/lib/parser_spec.rb
@@ -136,11 +136,11 @@ describe Parser do
     end
     
     it "should return a list of repos" do
-      expected = [['mrdoob', 'three.js'],
-        ['mozilla', 'narcissus'],
-        ['twinbit', 'Drupal-APT-Xapian'],
-        ['redsand', 'bl4ckJack'],
-        ['jgv', 'is-the-L-train-fucked']]
+      expected = [['mrdoob', 'three.js', 'Javascript 3D Engine'],
+        ['mozilla', 'narcissus', 'The Narcissus meta-circular JavaScript interpreter'],
+        ['twinbit', 'Drupal-APT-Xapian', 'APT Xapian Drupal module'],
+        ['redsand', 'bl4ckJack', ''],
+        ['jgv', 'is-the-L-train-fucked', "Simple utility to let you know if the L train isn't running well. Uses the MTA's API."]]
 
       Parser.new(url).trending_repos.should == expected
     end

--- a/views/show.builder
+++ b/views/show.builder
@@ -9,7 +9,7 @@ xml.rss :version => "2.0" do
       xml.item do
         xml.title "#{repo[0]} / #{repo[1]}"
         xml.link "http://github.com/#{repo[0]}/#{repo[1]}"
-        xml.description 
+        xml.description repo[2]
         xml.pubDate
         xml.guid "http://github.com/#{repo[0]}/#{repo[1]}" 
       end


### PR DESCRIPTION
Hi Oscar!

Here is a commit to have the repos description displayed directly in the feed. I think that's quite helpful. Unfortunately the repos descriptions are not displayed in the language specific views, so the repos descriptions are displayed only in the 'All Languages' feeds.

I've left a feature request in the GitHub support interface to have the repos descriptions in the language specific views. If GitHub adds it one day, I would send you another patch.

A workaround would be to fetch a repos description through the GitHub repositories API (http://develop.github.com/p/repo.html) but that would complexify a bit the github-trends code.
